### PR TITLE
add support for byte schema encoding

### DIFF
--- a/test/test_bytes.js
+++ b/test/test_bytes.js
@@ -1,0 +1,40 @@
+import avro from 'k6/x/avro';
+import encoding from 'k6/encoding';
+
+const keyCodec = avro.newCodec(`{
+  "type": "record",
+  "name": "TestKeyRecord",
+  "namespace": "org.test.schemas",
+  "fields": [
+    { "name": "uniqueID", "type": "long" },
+    { "name": "dummyStr", "type": "string" }
+  ]
+}`);
+
+const byteCodec = avro.newBytesCodec();
+
+export const options = {
+  vus: 1,
+  iterations: 1,
+};
+
+export default function () {
+  const dummyStr = "me-dummy";
+  const keys = [
+    { uniqueID: 247589500, dummyStr },
+    { uniqueID: 247589501, dummyStr }
+  ];
+
+  const byteEncodedArr = [];
+
+  for (const record of keys) {
+    const raw = keyCodec.binaryFromTextual(JSON.stringify(record));
+    const encodedBytes = byteCodec.encodeBytes(raw);
+    byteEncodedArr.push(...encodedBytes);
+  }
+
+  const combined = new Uint8Array(byteEncodedArr);
+  const base64Final = encoding.b64encode(combined, 'url');
+
+  console.log(`base64:${base64Final}`);
+}


### PR DESCRIPTION
add support for byte schema encoding

# Testing Done: 

```
➜  xk6-avro git:(encode-native) ✗ ./k6 run test/test_bytes.js

         /\      Grafana   /‾‾/
    /\  /  \     |\  __   /  /
   /  \/    \    | |/ /  /   ‾‾\
  /          \   |   (  |  (‾)  |
 / __________ \  |_|\_\  \_____/

     execution: local
        script: test/test_bytes.js
        output: -

     scenarios: (100.00%) 1 scenario, 1 max VUs, 10m30s max duration (incl. graceful stop):
              * default: 1 iterations shared among 1 VUs (maxDuration: 10m0s, gracefulStop: 30s)

INFO[0000] base64:HPipj-wBEG1lLWR1bW15HPqpj-wBEG1lLWR1bW15  source=console

     data_received........: 0 B 0 B/s
     data_sent............: 0 B 0 B/s
     iteration_duration...: avg=545.12µs min=545.12µs med=545.12µs max=545.12µs p(90)=545.12µs p(95)=545.12µs
     iterations...........: 1   1540.832049/s


running (00m00.0s), 0/1 VUs, 1 complete and 0 interrupted iterations
default ✓ [======================================] 1 VUs  00m00.0s/10m0s  1/1 shared iters
➜  xk6-avro git:(encode-native) ✗
```